### PR TITLE
Raven

### DIFF
--- a/alps/app.py
+++ b/alps/app.py
@@ -6,6 +6,7 @@ from flask import Flask, redirect, render_template, request, url_for
 from flask.ext.login import (LoginManager, login_required, login_user,
                              logout_user)
 from flask_wtf.csrf import CsrfProtect
+from raven.contrib.flask import Sentry
 
 from alps.config import read_config
 from alps.db import session, setup_session
@@ -39,6 +40,9 @@ def initialize_app(app=None, config_dict=None):
     if not isinstance(config_dict, collections.abc.Mapping):
         raise ValueError('argument config_dict is not a dictionary type')
     app.config.update(config_dict)
+
+    sentry = Sentry(dsn=app.config['SENTRY_DSN'])
+    sentry.init_app(app)
 
 
 try:

--- a/alps/app.py
+++ b/alps/app.py
@@ -28,9 +28,6 @@ login_manager.init_app(app)
 login_manager.login_view = 'login'
 csrf_protect.init_app(app)
 
-# import logging, sys
-# logging.basicConfig(stream=sys.stderr)
-
 
 def initialize_app(app=None, config_dict=None):
     if app is None:

--- a/example.cfg.yml
+++ b/example.cfg.yml
@@ -1,2 +1,3 @@
 DATABASE_URL: driver://user:pass@localhost/dbname
 SECRET_KEY: secret
+SENTRY_DSN: http://public_key:secret_key@example.com/1

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = {
     'Flask-WTF >= 0.11',
     'lxml >= 3.4.1',
     'PyYAML >= 3.11',
+    'raven >= 5.2.0',
     'SQLAlchemy >= 0.9.8',
 }
 


### PR DESCRIPTION
에러 로깅을 위한 센트리와 연동함.
configuration 파일에 `SENTRY_DSN`을 적어줄 것.
